### PR TITLE
fixes a build error using GCC or Apple-provided Clang on Mac OS 10.6

### DIFF
--- a/src/impl-apple-cheetah.cc
+++ b/src/impl-apple-cheetah.cc
@@ -23,7 +23,7 @@ Local<String> OSErrDescription(OSErr err) {
   return String::New("Could not get volume name");
 }
 
-Handle<Value> MethodGetVolumeName(const Arguments& args) {
+v8::Handle<Value> MethodGetVolumeName(const Arguments& args) {
   HandleScope scope;
 
   String::AsciiValue aPath(args[0]);


### PR DESCRIPTION
See issue #2.

The error was `expected constructor, destructor, or type conversion before ‘<’ token` and happened on Mac OS 10.6 with GCC and Clang from Xcode 3.2.6 and with GCC (at least) 4.7 and 4.8 provided by MacPorts; Clang 3.4 provided by MacPorts didn't have this problem.

I got a hint in the right direction from the error message of GCC 4.8 from MacPorts, that said `reference to 'Handle' is ambiguous`.

I tested the change with the mentioned compilers: they built without warnings, except for Clang from Xcode 3.2.6, which gave the warning `clang: warning: not using the clang compiler for C++ inputs`; with `mocha` all of them passed 3 tests and failed the volume name test the same way as described in https://github.com/LinusU/node-alias/pull/3#issuecomment-41367439, so they actually passed all tests.
