### PR TITLE
reenable and fix tests, integrate nan for broader node version support

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,7 +2,10 @@
   "targets": [
     {
       "target_name": "volume",
-      "sources": [ "src/volume.cc" ]
+      "sources": [ "src/volume.cc" ],
+      "include_dirs" : [
+        "<!(node -e \"require('nan')\")"
+      ]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "author": "Linus Unnebäck <linus@folkdatorn.se>",
   "contributors": [
     "Linus Unnebäck <linus@folkdatorn.se>",
-    "Davide Liessi <davide.liessi@gmail.com>"
+    "Davide Liessi <davide.liessi@gmail.com>",
+    "Joshua Warner <joshuawarner32@gmail.com>"
   ],
   "devDependencies": {
     "fs-temp": "^0.1.0",
@@ -18,5 +19,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/LinusU/node-alias.git"
+  },
+  "dependencies": {
+    "nan": "^1.4.1"
   }
 }

--- a/src/impl-apple-lion.cc
+++ b/src/impl-apple-lion.cc
@@ -2,12 +2,15 @@
 #include <CoreFoundation/CFURL.h>
 #include <CoreFoundation/CFString.h>
 
-using namespace v8;
+using v8::String;
+using v8::Exception;
+using v8::Local;
+using v8::Value;
 
 Local<String> MYCFStringGetV8String(CFStringRef aString) {
 
   if (aString == NULL) {
-    return String::New("");
+    return NanNew("");
   }
 
   CFIndex length = CFStringGetLength(aString);
@@ -16,19 +19,19 @@ Local<String> MYCFStringGetV8String(CFStringRef aString) {
 
   if (CFStringGetCString(aString, buffer, maxSize, kCFStringEncodingUTF8)) {
 
-    Local<String> result = String::New(buffer);
+    Local<String> result = NanNew(buffer);
     free(buffer);
 
     return result;
   }
 
-  return String::New("");
+  return NanNew("");
 }
 
-Handle<Value> MethodGetVolumeName(const Arguments& args) {
-  HandleScope scope;
+NAN_METHOD(MethodGetVolumeName) {
+   NanScope();
 
-  String::AsciiValue aPath(args[0]);
+  NanAsciiString aPath(args[0]);
 
   CFStringRef out;
   CFErrorRef error;
@@ -40,12 +43,12 @@ Handle<Value> MethodGetVolumeName(const Arguments& args) {
 
     Local<String> result = MYCFStringGetV8String(out);
 
-    return scope.Close(result);
+    NanReturnValue(result);
   } else {
 
     Local<String> desc = MYCFStringGetV8String(CFErrorCopyDescription(error));
-    ThrowException(Exception::Error(desc)->ToObject());
+    NanThrowError(Exception::Error(desc)->ToObject());
 
-    return scope.Close(Undefined());
+    NanReturnUndefined();
   }
 }

--- a/src/volume.cc
+++ b/src/volume.cc
@@ -1,4 +1,5 @@
 
+#include <nan.h>
 #include <node.h>
 #include <v8.h>
 
@@ -8,8 +9,10 @@
 #error This platform is not implemented yet
 #endif
 
-void init(v8::Handle<v8::Object> exports) {
-  exports->Set(v8::String::NewSymbol("getVolumeName"), v8::FunctionTemplate::New(MethodGetVolumeName)->GetFunction());
+using v8::FunctionTemplate;
+
+void Initialize(v8::Handle<v8::Object> exports) {
+  exports->Set(NanNew("getVolumeName"), NanNew<FunctionTemplate>(MethodGetVolumeName)->GetFunction());
 }
 
-NODE_MODULE(volume, init)
+NODE_MODULE(volume, Initialize)


### PR DESCRIPTION
It compiles and the tests pass for me on mac os 10.10, with both node 0.10.32 and 0.11.14.  However, it looks like the tests don't actually hit the native code (advice on what tests could be added here is welcome).

I made sure to test both the "cheetah" and "lion" code paths (by editing the source to include the other file).  Both compile, at least.

I'm guessing the dates on the tests had been broken for a while since the tests were not enabled.  Let me know if that might be a machine-specific thing, somehow.
