### PR TITLE
N-API

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -4,8 +4,20 @@
       "target_name": "volume",
       "sources": [ "src/volume.cc" ],
       "include_dirs" : [
-        "<!(node -e \"require('nan')\")"
-      ]
+        "<!@(node -p \"require('node-addon-api').include\")"
+      ],
+      "dependencies": [
+        "<!(node -p \"require('node-addon-api').gyp\")"
+      ],
+      "cflags!": [ "-fno-exceptions" ],
+      "cflags+": [ "-fvisibility=hidden" ],
+      "cflags_cc!": [ "-fno-exceptions" ],
+      "xcode_settings": {
+        "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+        "CLANG_CXX_LIBRARY": "libc++",
+        "MACOSX_DEPLOYMENT_TARGET": "10.7",
+        "GCC_SYMBOLS_PRIVATE_EXTERN": "YES"
+      }
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "url": "https://github.com/LinusU/node-alias.git"
   },
   "dependencies": {
-    "nan": "^2.4.0"
+    "node-addon-api": "^1.6.3"
   }
 }

--- a/src/impl-apple-cheetah.cc
+++ b/src/impl-apple-cheetah.cc
@@ -1,4 +1,6 @@
 
+#define NAPI_VERSION 3
+#include <napi.h>
 #include <Carbon/Carbon.h>
 #include <CoreFoundation/CFURL.h>
 #include <CoreFoundation/CFString.h>
@@ -20,10 +22,11 @@ const char* OSErrDescription(OSErr err) {
   return "Could not get volume name";
 }
 
-NAN_METHOD(MethodGetVolumeName) {
-  Nan::Utf8String aPath(info[0]);
+Napi::Value MethodGetVolumeName(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  std::string aPath = info[0].As<Napi::String>();
 
-  CFStringRef volumePath = CFStringCreateWithCString(NULL, *aPath, kCFStringEncodingUTF8);
+  CFStringRef volumePath = CFStringCreateWithCString(NULL, aPath.c_str(), kCFStringEncodingUTF8);
   CFURLRef url = CFURLCreateWithFileSystemPath(NULL, volumePath, kCFURLPOSIXPathStyle, true);
 
   OSErr err;
@@ -32,16 +35,16 @@ NAN_METHOD(MethodGetVolumeName) {
   HFSUniStr255 outString;
 
   if (CFURLGetFSRef(url, &urlFS) == false) {
-    return Nan::ThrowError("Failed to convert URL to file or directory object");
+    throw Napi::Error::New(env, "Failed to convert URL to file or directory object");
   }
 
   if ((err = FSGetCatalogInfo(&urlFS, kFSCatInfoVolume, &urlInfo, NULL, NULL, NULL)) != noErr) {
-    return Nan::ThrowError(OSErrDescription(err));
+    throw Napi::Error::New(env, OSErrDescription(err));
   }
 
   if ((err = FSGetVolumeInfo(urlInfo.volume, 0, NULL, kFSVolInfoNone, NULL, &outString, NULL)) != noErr) {
-    return Nan::ThrowError(OSErrDescription(err));
+    throw Napi::Error::New(env, OSErrDescription(err));
   }
 
-  info.GetReturnValue().Set(Nan::New<v8::String>(outString.unicode, outString.length).ToLocalChecked());
+  return Napi::String::New(env, reinterpret_cast<char16_t *>(outString.unicode), outString.length);
 }

--- a/src/volume.cc
+++ b/src/volume.cc
@@ -1,19 +1,13 @@
 
-#include <nan.h>
-#include <node.h>
-#include <v8.h>
-
 #ifdef __APPLE__
 #include "impl-apple.cc"
 #else
 #error This platform is not implemented yet
 #endif
 
-using v8::FunctionTemplate;
-
-NAN_MODULE_INIT(Initialize) {
-  Nan::Set(target, Nan::New("getVolumeName").ToLocalChecked(),
-    Nan::GetFunction(Nan::New<FunctionTemplate>(MethodGetVolumeName)).ToLocalChecked());
+Napi::Object Initialize(Napi::Env env, Napi::Object exports) {
+  exports["getVolumeName"] = Napi::Function::New(env, MethodGetVolumeName, "getVolumeName");
+  return exports;
 }
 
-NODE_MODULE(volume, Initialize)
+NODE_API_MODULE(volume, Initialize)


### PR DESCRIPTION
Currently, macos-alias doesn't work on Node 12. This PR fixes that (and prevents any other future V8 API breakages) by converting the native add-on to use N-API.