### PR TITLE
Refactor code to use modern Buffer creation API

### DIFF
--- a/lib/create.js
+++ b/lib/create.js
@@ -80,7 +80,7 @@ module.exports = exports = function (targetPath) {
   }());
 
   (function addType1 () {
-    var b = new Buffer(4)
+    var b = Buffer.alloc(4)
 
     b.writeUInt32BE(info.parent.id, 0)
 
@@ -93,7 +93,7 @@ module.exports = exports = function (targetPath) {
 
   (function addType14 () {
     var l = info.target.filename.length
-    var b = new Buffer(2 + (l * 2))
+    var b = Buffer.alloc(2 + (l * 2))
 
     b.writeUInt16BE(l, 0)
     utf16be(info.target.filename).copy(b, 2)
@@ -107,7 +107,7 @@ module.exports = exports = function (targetPath) {
 
   (function addType15 () {
     var l = info.volume.name.length
-    var b = new Buffer(2 + (l * 2))
+    var b = Buffer.alloc(2 + (l * 2))
 
     b.writeUInt16BE(l, 0)
     utf16be(info.volume.name).copy(b, 2)

--- a/lib/create.js
+++ b/lib/create.js
@@ -30,7 +30,7 @@ var findVolume = function (startPath, startStat) {
 }
 
 var utf16be = function (str) {
-  var b = new Buffer(str, 'ucs2')
+  var b = Buffer.from(str, 'ucs2')
   for (var i = 0; i < b.length; i += 2) {
     var a = b[i]
     b[i] = b[i + 1]
@@ -70,7 +70,7 @@ module.exports = exports = function (targetPath) {
   };
 
   (function addType0 () {
-    var b = new Buffer(info.parent.name, 'utf8')
+    var b = Buffer.from(info.parent.name, 'utf8')
 
     info.extra.push({
       type: 0,
@@ -123,7 +123,7 @@ module.exports = exports = function (targetPath) {
     var vl = volumePath.length
     assert.equal(targetPath.slice(0, vl), volumePath)
     var lp = targetPath.slice(vl)
-    var b = new Buffer(lp, 'utf8')
+    var b = Buffer.from(lp, 'utf8')
 
     info.extra.push({
       type: 18,
@@ -133,7 +133,7 @@ module.exports = exports = function (targetPath) {
   }());
 
   (function addType19 () {
-    var b = new Buffer(volumePath, 'utf8')
+    var b = Buffer.from(volumePath, 'utf8')
 
     info.extra.push({
       type: 19,

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -24,7 +24,7 @@ module.exports = exports = function (info) {
   }, 0)
   var trailerLength = 4
 
-  var buf = new Buffer(baseLength + extraLength + trailerLength)
+  var buf = Buffer.alloc(baseLength + extraLength + trailerLength)
 
   buf.writeUInt32BE(0, 0)
 

--- a/lib/is-alias.js
+++ b/lib/is-alias.js
@@ -6,7 +6,7 @@ module.exports = function isAlias (path) {
   var fd = fs.openSync(path, 'r')
 
   try {
-    read = new Buffer(16)
+    read = Buffer.alloc(16)
     fs.readSync(fd, read, 0, 16, 0)
   } finally {
     fs.closeSync(fd)

--- a/test/basics.js
+++ b/test/basics.js
@@ -7,7 +7,7 @@ var path = require('path')
 var temp = require('fs-temp')
 var assert = require('assert')
 
-var rawData = new Buffer(
+var rawData = Buffer.from(
   'AAAAAAEqAAIAAApUZXN0IFRpdGxlAAAAAAAAAAAAAAAAAAAAAADO615USCsA' +
   'BQAAABMMVGVzdEJrZy50aWZmAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' +
   'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFM7rXlgAAAAAAAAAAP////8A' +
@@ -70,8 +70,8 @@ describe('isAlias', function () {
   var aliasFile, garbageFile
 
   before(function () {
-    aliasFile = temp.writeFileSync(new Buffer('626f6f6b000000006d61726b00000000', 'hex'))
-    garbageFile = temp.writeFileSync(new Buffer('Hello my name is Linus!'))
+    aliasFile = temp.writeFileSync(Buffer.from('626f6f6b000000006d61726b00000000', 'hex'))
+    garbageFile = temp.writeFileSync(Buffer.from('Hello my name is Linus!'))
   })
 
   after(function () {


### PR DESCRIPTION
1. Refactor code to use modern `Buffer.alloc()` with zero-filled memory
2. Refactor code to use modern `Buffer.from()` creation api

Fixes the `'new Buffer()' was deprecated since v6.0.0. Use 'Buffer.alloc()' or 'Buffer.from()' instead. (n/no-deprecated-api)` error reported by `npx standard` linter.


### Buffer Creation API

In versions of Node.js prior to 6.0.0, `Buffer` instances were created using the `Buffer` constructor function, which allocates the returned `Buffer` differently based on what arguments are provided:

* Passing a number as the first argument to `Buffer()` (e.g. new Buffer(10)) allocates a new Buffer object of the specified size. Prior to Node.js 8.0.0, the memory allocated for such Buffer instances is not initialized and can contain sensitive data. Such Buffer instances must be subsequently initialized by using either [buf.fill(0)](https://nodejs.org/docs/latest/api/buffer.html#buffillvalue-offset-end-encoding) or by writing to the entire Buffer before reading data from the Buffer. While this behavior is intentional to improve performance, development experience has demonstrated that a more explicit distinction is required between creating a fast-but-uninitialized Buffer versus creating a slower-but-safer Buffer. Since Node.js 8.0.0, Buffer(num) and new Buffer(num) return a Buffer with initialized memory.

* Passing a string, array, or Buffer as the first argument copies the passed object's data into the Buffer.

* Passing an [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) or a [SharedArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) returns a Buffer that shares allocated memory with the given array buffer.

Reference: https://nodejs.org/docs/latest/api/buffer.html#buffer_buffer_from_buffer_alloc_and_buffer_allocunsafe