### PR TITLE
fix TypeError: util.isDate is not a function

### DIFF
--- a/lib/encode.js
+++ b/lib/encode.js
@@ -5,7 +5,7 @@ var values = require('./values')
 
 var appleEpoch = Date.UTC(1904, 0, 1)
 var appleDate = function (value) {
-  if (util.isDate(value) === false) {
+  if (!(value instanceof Date)) {
     // value = new Date(value);
     throw new TypeError('Not a date: ' + value)
   }


### PR DESCRIPTION
The solution provided by ChatGPT has indeed resolved the error after local testing, but whether to merge it should be evaluated by the author.
@LinusU 